### PR TITLE
Skip element by returning an empty array

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,31 @@ Does a flush/clear first and then imports the index again.
 ./craft scout/index/refresh <indexName?>
 ```
 
+## Skipping an Element
+
+You can omit an element from being indexed by returning an **empty array** from the `transform` method:
+
+```php
+public function transform(Entry $entry): array
+{
+    // Check if entry is valid for indexing
+    $isValid = yourCustomValidation($entry);
+    
+    // If entry fails validation, return empty array
+    if (!$isValid) {
+        return [];
+    }
+
+    // Return normal data attributes
+    return [
+        'name' => $entry->title,
+        ...
+        'lorem' => $entry->lorem,
+        'ipsum' => $entry->ipsum,
+    ];
+}
+```
+
 ## Credits
 - [Craft Algolia](https://github.com/aaronwaldon/craft-algolia) by aaronwaldon as a base to start from
 - @larsboldt for the Split Element Index option

--- a/src/models/AlgoliaIndex.php
+++ b/src/models/AlgoliaIndex.php
@@ -106,6 +106,12 @@ class AlgoliaIndex extends Model
         $fractal->setSerializer(new ArraySerializer());
 
         $data = $fractal->createData($resource)->toArray();
+
+        // If an empty array is returned, skip element
+        if (empty($data)) {
+            return;
+        }
+
         // Make sure the objectID is set (and unique) for Algolia
         $data['objectID'] = $this->getSiteElementId($element);
 
@@ -166,7 +172,9 @@ class AlgoliaIndex extends Model
         }
 
         foreach ($elementConfigs as $elementConfig) {
-            Craft::$app->queue->push(new IndexElement($elementConfig));
+            if ($elementConfig['element'] !== null) {
+                Craft::$app->queue->push(new IndexElement($elementConfig));
+            }
         }
     }
 


### PR DESCRIPTION
You can now skip an element based on the results of its `transform`.

If you'd like to omit an element from being indexed, you can simply return an **empty array**:

```php
public function transform(Entry $entry): array
{
    
    // Check if entry is valid for indexing
    $isValid = yourCustomValidation($entry);
    
    // If entry fails validation, return empty array
    if (!$isValid) {
        return [];
    }

    // Return normal data attributes
    return [
        'name' => $entry->title,
        ...
        'lorem' => $entry->lorem,
        'ipsum' => $entry->ipsum,
    ];

}
```