### PR TITLE
Fixed an issue with settings call

### DIFF
--- a/src/console/controllers/scout/SettingsController.php
+++ b/src/console/controllers/scout/SettingsController.php
@@ -65,7 +65,7 @@ class SettingsController extends BaseController
             $forwardToReplicas = $mapping->indexSettings['forwardToReplicas'] ?? null;
 
             if ($settings) {
-                $index->setSettings($settings, $forwardToReplicas ? ['forwardToReplicas' => $forwardToReplicas] : null);
+                $index->setSettings($settings, $forwardToReplicas ? ['forwardToReplicas' => $forwardToReplicas] : []);
             }
 
             $progress++;


### PR DESCRIPTION
Tiny adjustment. I was running into issues with running settings from the CLI and narrowed it down to this line.

-----

Request options must be an array or instance of `RequestOptions` to avoid a validation error.

```
[ERROR] RequestOptions can only be created from array or from RequestOptions object

         InvalidArgumentException

         in /project/vendor/algolia/algoliasearch-client-php/src/RequestOptions/RequestOptionsFactory.php: 50
```