### PR TITLE
Allow index settings to be forwarded to replicas

### DIFF
--- a/src/engines/AlgoliaEngine.php
+++ b/src/engines/AlgoliaEngine.php
@@ -86,7 +86,7 @@ class AlgoliaEngine extends Engine
     {
         $index = $this->algolia->initIndex($this->scoutIndex->indexName);
         $index->setSettings($indexSettings->settings, [
-            'forwardToReplicas' => $indexSettings->forwardToReplicas
+            'forwardToReplicas' => $indexSettings->forwardToReplicas,
         ]);
     }
 

--- a/src/engines/AlgoliaEngine.php
+++ b/src/engines/AlgoliaEngine.php
@@ -85,7 +85,9 @@ class AlgoliaEngine extends Engine
     public function updateSettings(IndexSettings $indexSettings)
     {
         $index = $this->algolia->initIndex($this->scoutIndex->indexName);
-        $index->setSettings($indexSettings->settings);
+        $index->setSettings($indexSettings->settings, [
+            'forwardToReplicas' => $indexSettings->forwardToReplicas
+        ]);
     }
 
     public function getSettings(): array


### PR DESCRIPTION
We're [able to set](https://github.com/riasvdv/craft-scout/blob/master/src/IndexSettings.php#L91-L93) whether we want index settings to forward to replicas or not in the index settings, but it looks like it doesn't ever actually make it to Algolia. So I've added the `forwardToReplicas` parameter to the `setSettings()` method per the [Algolia documentation](https://www.algolia.com/doc/api-reference/api-methods/set-settings/?language=php). This change has been tested on a project I'm currently working on fwiw...