### PR TITLE
getClient getter

### DIFF
--- a/src/engines/AlgoliaEngine.php
+++ b/src/engines/AlgoliaEngine.php
@@ -90,6 +90,11 @@ class AlgoliaEngine extends Engine
         ]);
     }
 
+    public function getClient(): Algolia
+    {
+        return $this->algolia;
+    }
+
     public function getSettings(): array
     {
         $index = $this->algolia->initIndex($this->scoutIndex->indexName);

--- a/tests/unit/AlgoliaEngineTest.php
+++ b/tests/unit/AlgoliaEngineTest.php
@@ -246,4 +246,10 @@ class AlgoliaEngineTest extends Unit
     {
         $this->assertEquals(0, $this->engine->getTotalRecords());
     }
+
+    /** @test * */
+    public function it_can_get_client()
+    {
+        $this->assertInstanceOf(SearchClient::class, $this->engine->getClient());
+    }
 }


### PR DESCRIPTION
I needed access to the client for one-off algolia operations, but `rias\scout\engines\AlgoliaEngine::algolia` was protected, so I couldn't.

This adds a getter, and should be non-breaking.

For a breaking change, it might make sense to move getClient to the base class, make the prop private, maybe rename to $client?

Conceptually at least, is the idea here that there might be a non-algolia engine (eg elasticsearch)?