### PR TITLE
Don't include indices in Settings::toArray() by default

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -42,6 +42,24 @@ class Settings extends Model
     /* @var int */
     public $batch_size = 1000;
 
+    public function fields()
+    {
+        $fields = parent::fields();
+
+        // don't include indices by default
+        unset($fields['indices']);
+
+        return $fields;
+    }
+
+    public function extraFields()
+    {
+        return [
+            'indices',
+            'engines',
+        ];
+    }
+
     public function rules()
     {
         return [


### PR DESCRIPTION
Fixes #152