### PR TITLE
Don’t fetch relations if sync is turned off

### DIFF
--- a/src/behaviors/SearchableBehavior.php
+++ b/src/behaviors/SearchableBehavior.php
@@ -120,6 +120,10 @@ class SearchableBehavior extends Behavior
 
     public function getRelatedElements(): Collection
     {
+        if (!Scout::$plugin->getSettings()->sync) {
+            return new Collection();
+        }
+
         $assets = Asset::find()->relatedTo($this->owner)->site('*')->all();
         $categories = Category::find()->relatedTo($this->owner)->site('*')->all();
         $entries = Entry::find()->relatedTo($this->owner)->site('*')->all();


### PR DESCRIPTION
tl;dr This adds a check that Scout’s `sync` setting is enabled before performing the expensive queries to fetch all of an element’s relations as it’s being deleted.

***

I have a Craft site using Scout with 1,000+ very large entries (60-200 matrix blocks each, ~20,000 words of text content each, etc.). The publishing workflow of the site involves programmatically creating a new draft of each entry at different points once a year and updating that draft with content generated outside of Craft. 

_Simplified example:_

```php
$article = Entry::findOne(123);
$draft = Craft::$app->getDrafts()->createDraft($article, $currentUserId);
$newContent = MyModule::$instance->myService->getUpdatedFieldsArray();
$draft->setFieldValues($newContent);
Craft::$app->getElements()->saveElement($draft);
```

This process was _extremely_ slow; on the production server it was taking 2-5 minutes per entry. In the process of debugging, I found that disabling Scout cut the time down to ~3 seconds per entry. Since this particular process should _never_ result in any public changes that would be reflected in Algolia, I added some code to disable and re-enable Scout’s `sync` setting around my draft creation process. 

_Simplified example:_ 

```php
Scout::$plugin->setSettings(['sync' => false]);

// Create the new draft, update the content, and save

Scout::$plugin->setSettings(['sync' => true]);
```

While this did help a little, and prevented Scout from pushing any updates to Algolia, the process was still taking 2+ minutes per entry. I narrowed the issue down further to Scout’s `Elements::EVENT_BEFORE_DELETE_ELEMENT` listener, which was being fired dozens of times. 

From what I can tell, when Craft creates the new draft of an entry, it also duplicates all of the associated matrix blocks. Then because I'm immediately overwriting those blocks with updated content, Craft was deleting each of those original duplicates. Each deleted block then hit Scout’s `Elements::EVENT_BEFORE_DELETE_ELEMENT` listener, which calls `->getRelatedElements()`. Fetching those related elements was taking ~3-6 seconds per block. Scout then loops through the returned collection of relations in the `Elements::EVENT_AFTER_DELETE_ELEMENT` listener and calls `->searchable()` on each to make any necessary index updates. But since `sync` is off, `searchable()` just bails early, so these queries essentially aren’t used when `sync` is off. 

This adds a check before fetching those relations to make sure `sync` is actually enabled and the queries are worth executing.
